### PR TITLE
Stop including shared library in java_wrap_cc runtime_deps.

### DIFF
--- a/java/defs.bzl
+++ b/java/defs.bzl
@@ -130,6 +130,11 @@ def java_wrap_cc(
 
     It's expected that the `swig` binary exists in the host's path.
 
+    Note that until https://github.com/bazelbuild/bazel/issues/3079 is fixed,
+    the resulting JAR may not automatically include a shared library of all
+    native deps. As a result, this macro also generates a shared library target
+    that you can include in your JAR resources.
+
     Args:
         name: target name.
         src: single .swig source file.
@@ -144,8 +149,8 @@ def java_wrap_cc(
         lib{name}.so: cc_binary
     """
 
-    wrapper_name = "_" + name + "_wrapper"
-    cc_name = "_" + name + "_cc"
+    wrapper_name = name + "-wrapper"
+    cc_name = name + "-cc"
     outfile = name + ".cc"
     srcjar = name + ".srcjar"
     so_name = "lib%s.so" % name
@@ -182,7 +187,7 @@ def java_wrap_cc(
     java_library(
         name = name,
         srcs = [srcjar],
-        runtime_deps = [so_name],
+        deps = [cc_name],
         visibility = visibility,
         **kwargs
     )

--- a/src/main/java/org/wfanet/BUILD.bazel
+++ b/src/main/java/org/wfanet/BUILD.bazel
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+java_library(
+    name = "jar_resources",
+    srcs = ["JarResources.java"],
+)

--- a/src/main/java/org/wfanet/JarResources.java
+++ b/src/main/java/org/wfanet/JarResources.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+public final class JarResources {
+  private static final String TEMP_DIR_PREFIX = "jar-resources";
+
+  /**
+   * Loads a library from a JAR resource.
+   *
+   * @param resourceName name of the resource within the JAR
+   */
+  public static void loadLibrary(String resourceName) {
+    Path tempDir;
+    try {
+      tempDir = Files.createTempDirectory(TEMP_DIR_PREFIX);
+    } catch (IOException e) {
+      throw new LinkageError("Unable to link " + resourceName, e);
+    }
+    tempDir.toFile().deleteOnExit();
+
+    URL resourceUrl =
+        requireNotNull(
+            JarResources.class.getClassLoader().getResource(resourceName), "Resource not found");
+    Path libPath = tempDir.resolve(getFileName(resourceName));
+    try (InputStream libStream = resourceUrl.openStream()) {
+      Files.copy(libStream, libPath, StandardCopyOption.REPLACE_EXISTING);
+    } catch (IOException e) {
+      throw new LinkageError("Unable to link " + resourceName, e);
+    }
+
+    System.load(libPath.toFile().getAbsolutePath());
+  }
+
+  private static String getFileName(String resourceName) {
+    int index = resourceName.lastIndexOf("/");
+    if (index == -1) {
+      return resourceName;
+    }
+    return resourceName.substring(index + 1);
+  }
+
+  private static <T> T requireNotNull(T item, String message) {
+    if (item == null) {
+      throw new IllegalArgumentException(message);
+    }
+    return item;
+  }
+}


### PR DESCRIPTION
This is a breaking change. It includes a Java util for loading a library from JAR resources.

The native library is included as a dep of the resulting java_library. According to the Bazel docs, this should result in a native shared library being included in the resulting JAR. According to bazelbuild/bazel#3079, this does not currently function as documented. Therefore, the macro generates a shared library target that the caller can include in JAR resources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/rules_swig/4)
<!-- Reviewable:end -->
